### PR TITLE
[FIX] 'vector' in namespace 'std' does not name a template type

### DIFF
--- a/include/default_init_allocator.hh
+++ b/include/default_init_allocator.hh
@@ -12,6 +12,7 @@
 #include <memory>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 // C++ Reference recommend to use this allocator implementation to
 // prevent containers resize invocation from initializing the allocated


### PR DESCRIPTION
In WSL2 with Ubuntu 20.04, when using clang++ to build this project, I meet this error.