### PR TITLE
Support for cuda and cuda header file

### DIFF
--- a/calltree.pl
+++ b/calltree.pl
@@ -154,7 +154,7 @@ my $ignore_pattern = join "", map {" --ignore '$_' "}
   qw(*test* *benchmark* *CMakeFiles* *contrib/* *third_party/*
     *thirdparty/* *3rd-[pP]arty/* *3rd[pP]arty/* *deps/*);
 
-my $cpp_filename_pattern = qq/'\\.(c|cc|cpp|C|h|hh|hpp|H)\$'/;
+my $cpp_filename_pattern = qq/'\\.(c|cc|cpp|cu|C|h|hh|hpp|cuh|H)\$'/;
 
 my $RE_IDENTIFIER = "\\b[A-Za-z_]\\w*\\b";
 my $RE_WS = "(?:\\s)";

--- a/calltree_fat.pl
+++ b/calltree_fat.pl
@@ -118,7 +118,7 @@ ensure_safe;
 ensure_ag_installed;
 
 my $ignore_pattern = join "", map {" --ignore '$_' "} qw(*test* *benchmark* *CMakeFiles* *contrib/* *thirdparty/* *3rd-[pP]arty/* *3rd[pP]arty/*);
-my $cpp_filename_pattern = qq/'\\.(c|cc|cpp|C|h|hh|hpp|H)\$'/;
+my $cpp_filename_pattern = qq/'\\.(c|cc|cpp|cu|C|h|hh|hpp|cuh|H)\$'/;
 
 my $RE_IDENTIFIER = "\\b[A-Za-z_]\\w*\\b";
 my $RE_WS = "(?:\\s)";

--- a/cpptree.pl
+++ b/cpptree.pl
@@ -58,7 +58,7 @@ sub ensure_ag_installed() {
 ensure_ag_installed;
 
 my $ignore_pattern = join "", map {" --ignore '$_' "} qw(*test* *benchmark* *CMakeFiles* *contrib/* *thirdparty/* *3rd-[pP]arty/* *3rd[pP]arty/*);
-my $cpp_filename_pattern = qq/'\\.(c|cc|cpp|C|h|hh|hpp|H)\$'/;
+my $cpp_filename_pattern = qq/'\\.(c|cc|cpp|cu|C|h|hh|hpp|cuh|H)\$'/;
 
 sub multiline_break_enabled() {
   my ($enabled) = map {chomp;

--- a/deptree.pl
+++ b/deptree.pl
@@ -154,7 +154,7 @@ my $ignore_pattern = join "", map {" --ignore '$_' "}
   qw(*test* *benchmark* *CMakeFiles* *contrib/* *third_party/*
     *thirdparty/* *3rd-[pP]arty/* *3rd[pP]arty/* *deps/*);
 
-my $cpp_filename_pattern = qq/'\\.(c|cc|cpp|C|h|hh|hpp|H)\$'/;
+my $cpp_filename_pattern = qq/'\\.(c|cc|cpp|cu|C|h|hh|hpp|cuh|H)\$'/;
 
 my $RE_WS = "(?:\\s)";
 my $RE_WS_NON_NL = "(?:[\\t\\x{20}])";


### PR DESCRIPTION
I think it is enough to add cuda and cuda header files. Because the front end of the compiler processes CUDA source files according to C++ syntax rules. 

Signed-off-by: Cerdore <khn64@163.com>