### PR TITLE
remove template from class name xxx_template mistakenly

### DIFF
--- a/javatree.pl
+++ b/javatree.pl
@@ -437,28 +437,27 @@ sub register_abnormal_shutdown_hook() {
 }
 
 sub all_sub_classes() {
-  my $access_specifier_re = "final|private|public|protected|abstract";
+  my $access_specifier_re = "\\b(?:final|private|public|protected|abstract)\\b";
   my $cls_re = "^[ \\t]*\\b(class|interface)\\b\\s*([a-zA-Z_]\\w*)\\s*[^{]*?{";
-  my $cls_filter_re = "^(\\S+)\\s*:\\s*(?:class|interface)\\s+\\w+(\\s+:\\s+(\\s*[:\\w]+\\s*,\\s*)*[:\\w]+)?s*";
+  my $cls_filter_re = "^(\\S+)\\s*:\\s*\\b(?:class|interface)\\b\\s+\\w+(\\s+:\\s+(\\s*[:\\w]+\\s*,\\s*)*[:\\w]+)?s*";
 
   my $class0_re = "(?:class|interface)\\s+($RE_CLASS)";
 
-  my $class1_0_re = "(?:class|interface)\\s+($RE_CLASS)\\s*extends\\s*($RE_CLASS)";
-  my $class2_0_re = "(?:class|interface)\\s+($RE_CLASS)\\s*extends(?:\\s*$RE_CLASS\\s*)\\s*implements\\s*($RE_CLASS)";
-  my $class3_0_re = "(?:class|interface)\\s+($RE_CLASS)\\s*extends(?:\\s*$RE_CLASS\\s*)\\s*implements(?:\\s*$RE_CLASS\\s*,){1}\\s*($RE_CLASS)";
-  my $class4_0_re = "(?:class|interface)\\s+($RE_CLASS)\\s*extends(?:\\s*$RE_CLASS\\s*)\\s*implements(?:\\s*$RE_CLASS\\s*,){2}\\s*($RE_CLASS)";
-  my $class5_0_re = "(?:class|interface)\\s+($RE_CLASS)\\s*extends(?:\\s*$RE_CLASS\\s*)\\s*implements(?:\\s*$RE_CLASS\\s*,){3}\\s*($RE_CLASS)";
-  my $class6_0_re = "(?:class|interface)\\s+($RE_CLASS)\\s*extends(?:\\s*$RE_CLASS\\s*)\\s*implements(?:\\s*$RE_CLASS\\s*,){4}\\s*($RE_CLASS)";
-  my $class7_0_re = "(?:class|interface)\\s+($RE_CLASS)\\s*extends(?:\\s*$RE_CLASS\\s*)\\s*implements(?:\\s*$RE_CLASS\\s*,){5}\\s*($RE_CLASS)";
+  my $class1_0_re = "\\b(?:class|interface)\\b\\s+($RE_CLASS)\\s*extends\\s*($RE_CLASS)";
+  my $class2_0_re = "\\b(?:class|interface)\\b\\s+($RE_CLASS)\\s*extends(?:\\s*$RE_CLASS\\s*)\\s*implements\\s*($RE_CLASS)";
+  my $class3_0_re = "\\b(?:class|interface)\\b\\s+($RE_CLASS)\\s*extends(?:\\s*$RE_CLASS\\s*)\\s*implements(?:\\s*$RE_CLASS\\s*,){1}\\s*($RE_CLASS)";
+  my $class4_0_re = "\\b(?:class|interface)\\b\\s+($RE_CLASS)\\s*extends(?:\\s*$RE_CLASS\\s*)\\s*implements(?:\\s*$RE_CLASS\\s*,){2}\\s*($RE_CLASS)";
+  my $class5_0_re = "\\b(?:class|interface)\\b\\s+($RE_CLASS)\\s*extends(?:\\s*$RE_CLASS\\s*)\\s*implements(?:\\s*$RE_CLASS\\s*,){3}\\s*($RE_CLASS)";
+  my $class6_0_re = "\\b(?:class|interface)\\b\\s+($RE_CLASS)\\s*extends(?:\\s*$RE_CLASS\\s*)\\s*implements(?:\\s*$RE_CLASS\\s*,){4}\\s*($RE_CLASS)";
+  my $class7_0_re = "\\b(?:class|interface)\\b\\s+($RE_CLASS)\\s*extends(?:\\s*$RE_CLASS\\s*)\\s*implements(?:\\s*$RE_CLASS\\s*,){5}\\s*($RE_CLASS)";
 
-  my $class1_1_re = "(?:class|interface)\\s+($RE_CLASS)\\s*implements\\s*($RE_CLASS)";
-  print "class1_1_re=$class1_1_re\n";
-  my $class2_1_re = "(?:class|interface)\\s+($RE_CLASS)\\s*implements(?:\\s*$RE_CLASS\\s*,){1}\\s*($RE_CLASS)";
-  my $class3_1_re = "(?:class|interface)\\s+($RE_CLASS)\\s*implements(?:\\s*$RE_CLASS\\s*,){2}\\s*($RE_CLASS)";
-  my $class4_1_re = "(?:class|interface)\\s+($RE_CLASS)\\s*implements(?:\\s*$RE_CLASS\\s*,){3}\\s*($RE_CLASS)";
-  my $class5_1_re = "(?:class|interface)\\s+($RE_CLASS)\\s*implements(?:\\s*$RE_CLASS\\s*,){4}\\s*($RE_CLASS)";
-  my $class6_1_re = "(?:class|interface)\\s+($RE_CLASS)\\s*implements(?:\\s*$RE_CLASS\\s*,){5}\\s*($RE_CLASS)";
-  my $class7_1_re = "(?:class|interface)\\s+($RE_CLASS)\\s*implements(?:\\s*$RE_CLASS\\s*,){6}\\s*($RE_CLASS)";
+  my $class1_1_re = "\\(?:class|interface)\\b\\s+($RE_CLASS)\\s*implements\\s*($RE_CLASS)";
+  my $class2_1_re = "\\(?:class|interface)\\b\\s+($RE_CLASS)\\s*implements(?:\\s*$RE_CLASS\\s*,){1}\\s*($RE_CLASS)";
+  my $class3_1_re = "\\(?:class|interface)\\b\\s+($RE_CLASS)\\s*implements(?:\\s*$RE_CLASS\\s*,){2}\\s*($RE_CLASS)";
+  my $class4_1_re = "\\(?:class|interface)\\b\\s+($RE_CLASS)\\s*implements(?:\\s*$RE_CLASS\\s*,){3}\\s*($RE_CLASS)";
+  my $class5_1_re = "\\(?:class|interface)\\b\\s+($RE_CLASS)\\s*implements(?:\\s*$RE_CLASS\\s*,){4}\\s*($RE_CLASS)";
+  my $class6_1_re = "\\(?:class|interface)\\b\\s+($RE_CLASS)\\s*implements(?:\\s*$RE_CLASS\\s*,){5}\\s*($RE_CLASS)";
+  my $class7_1_re = "\\(?:class|interface)\\b\\s+($RE_CLASS)\\s*implements(?:\\s*$RE_CLASS\\s*,){6}\\s*($RE_CLASS)";
 
   my @matches = ();
 


### PR DESCRIPTION
analyze seastar
```
cpptree.pl 'app.*' '' 1 0
```
unexpect behavior
```
  app.*
  ├── app_	[vim include/seastar/core/app-template.hh +38]
  ├── append_challenged_posix_file_impl	[vim src/core/file-impl.hh +195]
  ├── blob_wrapper	[vim src/net/tls.cc +55]
  ├── cpuset_bpo_wrapper	[vim include/seastar/core/resource.hh +101]
  ├── lazy_deref_wrapper	[vim include/seastar/util/lazy.hh +89]
  ├── mapping	[vim src/http/mime_types.cc +18]
  ├── reference_wrapper_for_es	[vim include/seastar/core/execution_stage.hh +88]
  ├── result_of_apply	[vim include/seastar/core/future.hh +1275]
  ├── result_of_apply	[vim include/seastar/core/future.hh +1280]
  ├── usecfmt_wrapper	[vim include/seastar/core/print.hh +96]
  ├── internal::uninitialized_wrapper	[vim out-of-tree]
  │   └── future_state	[vim include/seastar/core/future.hh +577]
  ├── reference_wrapper	[vim include/seastar/util/reference_wrapper.hh +43]
  │   └── reference_wrapper_for_es	[vim include/seastar/core/execution_stage.hh +88]
  ├── uninitialized_wrapper	[vim include/seastar/core/future.hh +367]
  │   └── future_state	[vim include/seastar/core/future.hh +577]
  ├── uninitialized_wrapper_base	[vim include/seastar/core/future.hh +294]
  │   └── uninitialized_wrapper	[vim include/seastar/core/future.hh +367]
  │       └── future_state	[vim include/seastar/core/future.hh +577]
  └── uninitialized_wrapper_base	[vim include/seastar/core/future.hh +324]
      └── uninitialized_wrapper	[vim include/seastar/core/future.hh +367]
          └── future_state	[vim include/seastar/core/future.hh +577]
```
expected behavior
```
  app.*
  ├── app_template	[vim include/seastar/core/app-template.hh +38]
  ├── append_challenged_posix_file_impl	[vim src/core/file-impl.hh +195]
  ├── blob_wrapper	[vim src/net/tls.cc +55]
  ├── cpuset_bpo_wrapper	[vim include/seastar/core/resource.hh +101]
  ├── lazy_deref_wrapper	[vim include/seastar/util/lazy.hh +89]
  ├── mapping	[vim src/http/mime_types.cc +18]
  ├── reference_wrapper_for_es	[vim include/seastar/core/execution_stage.hh +88]
  ├── result_of_apply	[vim include/seastar/core/future.hh +1275]
  ├── result_of_apply	[vim include/seastar/core/future.hh +1280]
  ├── usecfmt_wrapper	[vim include/seastar/core/print.hh +96]
  ├── internal::uninitialized_wrapper	[vim out-of-tree]
  │   └── future_state	[vim include/seastar/core/future.hh +577]
  ├── reference_wrapper	[vim include/seastar/util/reference_wrapper.hh +43]
  │   └── reference_wrapper_for_es	[vim include/seastar/core/execution_stage.hh +88]
  ├── uninitialized_wrapper	[vim include/seastar/core/future.hh +367]
  │   └── future_state	[vim include/seastar/core/future.hh +577]
  ├── uninitialized_wrapper_base	[vim include/seastar/core/future.hh +294]
  │   └── uninitialized_wrapper	[vim include/seastar/core/future.hh +367]
  │       └── future_state	[vim include/seastar/core/future.hh +577]
  └── uninitialized_wrapper_base	[vim include/seastar/core/future.hh +324]
      └── uninitialized_wrapper	[vim include/seastar/core/future.hh +367]
          └── future_state	[vim include/seastar/core/future.hh +577]
```