### PR TITLE
bugfix cpptree.pl

### DIFF
--- a/cpptree.pl
+++ b/cpptree.pl
@@ -429,19 +429,19 @@ sub register_abnormal_shutdown_hook() {
 
 sub all_sub_classes() {
   my $attr_re = "\\[\\[[^\\[\\]]+\\]\\]";
-  my $access_specifier_re = "final|private|public|protected";
+  my $access_specifier_re = "\\b(?:final|private|public|protected)\\b";
   my $template_arguments_re = "<([^<>]*(?:<(?1)>|[^<>])[^<>]*)?>";
-  my $cls_re = "^[ \\t]*(template\\s*$template_arguments_re)?(?:\\s*typedef)?[ \\t]*\\b(class|struct)\\b\\s*([a-zA-Z_]\\w*)\\s*[^{};*()=]*?{";
+  my $cls_re = "^[ \\t]*(\\btemplate\\b\\s*$template_arguments_re)?(?:\\s*\\btypedef\\b)?[ \\t]*\\b(class|struct)\\b\\s*([a-zA-Z_]\\w*)\\s*[^{};*()=]*?{";
   print "cls_re=$cls_re\n";
-  my $cls_filter_re = "^(\\S+)\\s*:\\s*(?:class|struct)\\s+\\w+(\\s+:\\s+(\\s*[:\\w]+\\s*,\\s*)*[:\\w]+)?s*";
+  my $cls_filter_re = "^(\\S+)\\s*:\\s*\\b(?:class|struct)\\b\\s+\\w+(\\s+:\\s+(\\s*[:\\w]+\\s*,\\s*)*[:\\w]+)?s*";
 
-  my $class0_re = "(?:class|struct)\\s+($RE_CLASS)";
-  my $class1_re = "(?:class|struct)\\s+($RE_CLASS)\\s*:\\s*($RE_CLASS)";
-  my $class2_re = "(?:class|struct)\\s+($RE_CLASS)\\s*:(?:\\s*$RE_CLASS\\s*,){1}\\s*($RE_CLASS)";
-  my $class3_re = "(?:class|struct)\\s+($RE_CLASS)\\s*:(?:\\s*$RE_CLASS\\s*,){2}\\s*($RE_CLASS)";
-  my $class4_re = "(?:class|struct)\\s+($RE_CLASS)\\s*:(?:\\s*$RE_CLASS\\s*,){3}\\s*($RE_CLASS)";
-  my $class5_re = "(?:class|struct)\\s+($RE_CLASS)\\s*:(?:\\s*$RE_CLASS\\s*,){4}\\s*($RE_CLASS)";
-  my $class6_re = "(?:class|struct)\\s+($RE_CLASS)\\s*:(?:\\s*$RE_CLASS\\s*,){5}\\s*($RE_CLASS)";
+  my $class0_re = "\\b(?:class|struct)\\b\\s+($RE_CLASS)";
+  my $class1_re = "\\b(?:class|struct)\\b\\s+($RE_CLASS)\\s*:\\s*($RE_CLASS)";
+  my $class2_re = "\\b(?:class|struct)\\b\\s+($RE_CLASS)\\s*:(?:\\s*$RE_CLASS\\s*,){1}\\s*($RE_CLASS)";
+  my $class3_re = "\\b(?:class|struct)\\b\\s+($RE_CLASS)\\s*:(?:\\s*$RE_CLASS\\s*,){2}\\s*($RE_CLASS)";
+  my $class4_re = "\\b(?:class|struct)\\b\\s+($RE_CLASS)\\s*:(?:\\s*$RE_CLASS\\s*,){3}\\s*($RE_CLASS)";
+  my $class5_re = "\\b(?:class|struct)\\b\\s+($RE_CLASS)\\s*:(?:\\s*$RE_CLASS\\s*,){4}\\s*($RE_CLASS)";
+  my $class6_re = "\\b(?:class|struct)\\b\\s+($RE_CLASS)\\s*:(?:\\s*$RE_CLASS\\s*,){5}\\s*($RE_CLASS)";
 
   my $cache_file = ".cpptree.list";
   my @matches = ();
@@ -480,7 +480,7 @@ sub all_sub_classes() {
     my @file_info = map {$_->[0]} @file_info_and_line;
     my @line = map {$_->[1]} @file_info_and_line;
 
-    my @transform_re = ($attr_re, $access_specifier_re, ($template_arguments_re) x 4, "template", "\\s*{\$", "(?<=\\s)\\s+");
+    my @transform_re = ($attr_re, $access_specifier_re, ($template_arguments_re) x 4, "\\btemplate\\b", "\\s*{\$", "(?<=\\s)\\s+");
     for my $re (@transform_re) {
       @line = map {s/$re//g;
         $_} @line;


### PR DESCRIPTION
analyze seastar
```
cpptree.pl 'app.*' '' 1 0
```
unexpect behavior
```
  app.*
  ├── app_	[vim include/seastar/core/app-template.hh +38]
  ├── append_challenged_posix_file_impl	[vim src/core/file-impl.hh +195]
  ├── blob_wrapper	[vim src/net/tls.cc +55]
  ├── cpuset_bpo_wrapper	[vim include/seastar/core/resource.hh +101]
  ├── lazy_deref_wrapper	[vim include/seastar/util/lazy.hh +89]
  ├── mapping	[vim src/http/mime_types.cc +18]
  ├── reference_wrapper_for_es	[vim include/seastar/core/execution_stage.hh +88]
  ├── result_of_apply	[vim include/seastar/core/future.hh +1275]
  ├── result_of_apply	[vim include/seastar/core/future.hh +1280]
  ├── usecfmt_wrapper	[vim include/seastar/core/print.hh +96]
  ├── internal::uninitialized_wrapper	[vim out-of-tree]
  │   └── future_state	[vim include/seastar/core/future.hh +577]
  ├── reference_wrapper	[vim include/seastar/util/reference_wrapper.hh +43]
  │   └── reference_wrapper_for_es	[vim include/seastar/core/execution_stage.hh +88]
  ├── uninitialized_wrapper	[vim include/seastar/core/future.hh +367]
  │   └── future_state	[vim include/seastar/core/future.hh +577]
  ├── uninitialized_wrapper_base	[vim include/seastar/core/future.hh +294]
  │   └── uninitialized_wrapper	[vim include/seastar/core/future.hh +367]
  │       └── future_state	[vim include/seastar/core/future.hh +577]
  └── uninitialized_wrapper_base	[vim include/seastar/core/future.hh +324]
      └── uninitialized_wrapper	[vim include/seastar/core/future.hh +367]
          └── future_state	[vim include/seastar/core/future.hh +577]
```
expected behavior
```
  app.*
  ├── app_template	[vim include/seastar/core/app-template.hh +38]
  ├── append_challenged_posix_file_impl	[vim src/core/file-impl.hh +195]
  ├── blob_wrapper	[vim src/net/tls.cc +55]
  ├── cpuset_bpo_wrapper	[vim include/seastar/core/resource.hh +101]
  ├── lazy_deref_wrapper	[vim include/seastar/util/lazy.hh +89]
  ├── mapping	[vim src/http/mime_types.cc +18]
  ├── reference_wrapper_for_es	[vim include/seastar/core/execution_stage.hh +88]
  ├── result_of_apply	[vim include/seastar/core/future.hh +1275]
  ├── result_of_apply	[vim include/seastar/core/future.hh +1280]
  ├── usecfmt_wrapper	[vim include/seastar/core/print.hh +96]
  ├── internal::uninitialized_wrapper	[vim out-of-tree]
  │   └── future_state	[vim include/seastar/core/future.hh +577]
  ├── reference_wrapper	[vim include/seastar/util/reference_wrapper.hh +43]
  │   └── reference_wrapper_for_es	[vim include/seastar/core/execution_stage.hh +88]
  ├── uninitialized_wrapper	[vim include/seastar/core/future.hh +367]
  │   └── future_state	[vim include/seastar/core/future.hh +577]
  ├── uninitialized_wrapper_base	[vim include/seastar/core/future.hh +294]
  │   └── uninitialized_wrapper	[vim include/seastar/core/future.hh +367]
  │       └── future_state	[vim include/seastar/core/future.hh +577]
  └── uninitialized_wrapper_base	[vim include/seastar/core/future.hh +324]
      └── uninitialized_wrapper	[vim include/seastar/core/future.hh +367]
          └── future_state	[vim include/seastar/core/future.hh +577]
```